### PR TITLE
Fix short text not rendering

### DIFF
--- a/src/main/java/com/woof/chattanova/handlers/ServerChatHandler.java
+++ b/src/main/java/com/woof/chattanova/handlers/ServerChatHandler.java
@@ -89,6 +89,9 @@ public class ServerChatHandler {
             if(runningWidth + siblingWidth <= maxWidth){
                 runningWidth += siblingWidth;
                 storageComponent.append(sibling); //this may need to have withStyle added
+                if(finalChecker == siblings.size()){
+                    returnList.add(0, storageComponent);
+                }
                 continue;
             }
 


### PR DESCRIPTION
Fixes an issue where the final sibling wasn't being returned in the list of components if a linebreak occurred right before it