### PR TITLE
Fix no spacing between merged components

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a nifty little mod that splits (future) configurable chats from the stan
 That's about it!
 
 ## TO-DO:
+- **BUGFIX: Remove reliance on listMerger to prevent excessively long words from being broken up with an unnecessary space**
 - **Add filter configuration**
 - **Add a fancy UI**
 - **Add some functionality to create multiple windows each with different filters**

--- a/src/main/java/com/woof/chattanova/handlers/ServerChatHandler.java
+++ b/src/main/java/com/woof/chattanova/handlers/ServerChatHandler.java
@@ -149,7 +149,7 @@ public class ServerChatHandler {
     private static ITextComponent listMerger(List<ITextComponent> list, Style style){
         TextComponent returnComponent = new StringTextComponent("");
         for(int i = list.size()-1; i >= 0; i--){
-            returnComponent.append(list.get(i)).withStyle(style);
+            returnComponent.append(list.get(i)).withStyle(style).append(" ");
         }
         return returnComponent;
     }


### PR DESCRIPTION
Fixes a bug where listMerger doesn't render space between each previously split component.

NOTE: This is a bandaid solution and the proper solution removes the need of listMerger entirely. Effectively, use the splitter to find the first string, separate that from the original component instead of breaking it all down and remerging it.